### PR TITLE
Reproduces the error with unloading eager loaded class

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,16 @@
+class User < ApplicationRecord
+  include Stripe::Callbacks
+
+  def say_tootsie
+    puts 'tootsie!'
+  end
+
+  def say_hello
+    puts 'hello!'
+  end
+
+  after_customer_updated! do |_customer, _event|
+    # User.new.say_hello
+    User.new.say_tootsie
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,16 +1,11 @@
 class User < ApplicationRecord
   include Stripe::Callbacks
 
-  def say_tootsie
-    puts 'tootsie!'
-  end
-
   def say_hello
     puts 'hello!'
   end
 
   after_customer_updated! do |_customer, _event|
-    # User.new.say_hello
-    User.new.say_tootsie
+    User.new.say_hello
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,12 @@ class User < ApplicationRecord
     puts 'hello!'
   end
 
+  def say_bye
+    puts 'bye!'
+  end
+
   after_customer_updated! do |_customer, _event|
     User.new.say_hello
+    # User.new.say_bye
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,6 @@
 Rails.application.configure do
+  config.stripe.eager_load = ['user']
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's

--- a/db/migrate/20190725200227_create_users.rb
+++ b/db/migrate/20190725200227_create_users.rb
@@ -1,0 +1,7 @@
+class CreateUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :users do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,20 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20190725200227) do
+
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+require 'stripe/rails/testing'
+
+class UserTest < ActionMailer::TestCase
+  test 'test reloading User model' do
+    StripeMock.start
+    user = User.new
+    Stripe::Rails::Testing.send_event 'customer.updated'
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -4,7 +4,6 @@ require 'stripe/rails/testing'
 class UserTest < ActionMailer::TestCase
   test 'test reloading User model' do
     StripeMock.start
-    user = User.new
     Stripe::Rails::Testing.send_event 'customer.updated'
   end
 end


### PR DESCRIPTION
I've set up the test to output the following when running `spring rake test`

```
# Running:

hello!
.
```

## Expectation when running stripe-rails 1.8.0

Based on the description on https://github.com/tansengming/stripe-rails/issues/155 the expectation is that

1. running the `spring rake test` for the first time will show

```
# Running:

hello!
.
```

2. forcing a reload of spring by writing to `user.rb` and running `spring rake test` again will show

```
# Running:

.
```

This fails as expected.

## What happens when running with https://github.com/tansengming/stripe-rails/pull/156

1. running the `spring rake test` for the first time will show

```
# Running:

hello!
.
```

2. forcing a reload of spring by writing to `user.rb` and running `spring rake test` again will error.

```
# Running:

E

Error:
UserTest#test_test_reloading_User_model:
ArgumentError: A copy of User has been removed from the module tree but is still active!
    app/models/user.rb:13:in `block in <class:User>'
    test/models/user_test.rb:7:in `block in <class:UserTest>'
```

I have feeling this happens because the old callback cache still has the previous version of the User class.

## what happens when running with https://github.com/tansengming/stripe-rails/pull/159

1. running the `spring rake test` for the first time will show

```
# Running:

hello!
.
```

2. forcing a reload of spring by writing to `user.rb` then running `spring rake test` again will show

```
# Running:

hello!
.
```

This works as expected.